### PR TITLE
Fix error in qgep export of attribute financing

### DIFF
--- a/qgepqwat2ili/qgep/export.py
+++ b/qgepqwat2ili/qgep/export.py
@@ -124,7 +124,7 @@ def qgep_export(selection=None):
             "detailgeometrie": ST_Force2D(row.detail_geometry_geometry),
             "eigentuemerref": get_tid(row.fk_owner__REL),
             "ersatzjahr": row.year_of_replacement,
-            "finanzierung": row.financing,
+            "finanzierung": get_vl(row.financing__REL),
             "inspektionsintervall": row.inspection_interval,
             "sanierungsbedarf": get_vl(row.renovation_necessity__REL),
             "standortname": row.location_name,


### PR DESCRIPTION
Hi! Thank you for your awesome work!
I am currently testing QGEP to see if one day we could use it productively.

While testing exports to SIA405 Abwasser 2015 i get the following error messages from ilivalidator:
```
Error: line 822: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Kanal: tid ch19qnvgnyBxTsY4: value 5511 is not a member of the enumeration in attribute Finanzierung
Error: line 823: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Kanal: tid ch19qnvgVBMDycJ2: value 5511 is not a member of the enumeration in attribute Finanzierung
Error: line 824: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Kanal: tid ch19qnvgyDLhXvDB: value 5511 is not a member of the enumeration in attribute Finanzierung
Error: line 825: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Kanal: tid ch19qnvgwTi5CEVJ: value 5511 is not a member of the enumeration in attribute Finanzierung
Error: line 826: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Kanal: tid ch19qnvgGM8pGx6j: value 5510 is not a member of the enumeration in attribute Finanzierung
Error: line 827: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Normschacht: tid ch19qnvgKRREiv0g: value 5510 is not a member of the enumeration in attribute Finanzierung
Error: line 828: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Normschacht: tid ch19qnvgNnE1DmfS: value 5510 is not a member of the enumeration in attribute Finanzierung
Error: line 829: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Normschacht: tid ch19qnvgR2KHjYSz: value 5511 is not a member of the enumeration in attribute Finanzierung
Error: line 830: SIA405_ABWASSER_2015_LV95.SIA405_Abwasser.Normschacht: tid ch19qnvg0HjxGal6: value 5512 is not a member of the enumeration in attribute Finanzierung
```

This adjustment does fix these errors. 

Of course I saw that the mapping of wastewater_structure is not fully implemented yet, so I figured maybe I could make a small contribution. 

Cheers, Benjamin
