### PR TITLE
2022-12 Change filter wastewater structures

### DIFF
--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -255,7 +255,9 @@ def action_export(plugin, pgservice=None):
         log_handler.setLevel(logging.INFO)
         log_handler.setFormatter(logging.Formatter("%(levelname)-8s %(message)s"))
         with LoggingHandlerContext(log_handler):
-            qgep_export(selection=export_dialog.selected_ids, labels_file=labels_file_path)
+            # 12.12.2022
+            #qgep_export(selection=export_dialog.selected_ids, labels_file=labels_file_path)
+            qgep_export(selection=export_dialog.selected_ids, selection2=export_dialog.selected_wws, labels_file=labels_file_path)
         progress_dialog.setValue(50)
 
         # Cleanup

--- a/qgepqwat2ili/gui/gui_export.py
+++ b/qgepqwat2ili/gui/gui_export.py
@@ -80,6 +80,17 @@ class GuiExport(QDialog):
         else:
             return None
 
+    # neu 12.12.2022
+    @property
+    def selected_wws(self):
+        if self.limit_checkbox.isChecked():
+            ids = []
+            for struct in self.structures:
+                ids.append(str(struct["obj_id"]))
+            return ids
+        else:
+            return None
+
     @property
     def limit_to_selection(self):
         return self.limit_checkbox.isChecked()

--- a/qgepqwat2ili/qgep/export.py
+++ b/qgepqwat2ili/qgep/export.py
@@ -10,12 +10,15 @@ from .model_abwasser import get_abwasser_model
 from .model_qgep import get_qgep_model
 
 
-def qgep_export(selection=None, labels_file=None):
+# 12.12.2022
+# def qgep_export(selection=None, labels_file=None):
+def qgep_export(selection=None, selection2=None, labels_file=None):
     """
     Export data from the QGEP model into the ili2pg model.
 
     Args:
         selection:      if provided, limits the export to networkelements that are provided in the selection
+        selection2:      if provided, adds additional wastewater_nodes of selected wastewater_structures
     """
 
     QGEP = get_qgep_model()
@@ -31,6 +34,8 @@ def qgep_export(selection=None, labels_file=None):
     # Filtering
     filtered = selection is not None
     subset_ids = selection if selection is not None else []
+    # 12.12.2022
+    wws_ids = selection2 if selection2 is not None else []
 
     def get_tid(relation):
         """
@@ -501,7 +506,11 @@ def qgep_export(selection=None, labels_file=None):
     logger.info("Exporting QGEP.wastewater_node -> ABWASSER.abwasserknoten, ABWASSER.metaattribute")
     query = qgep_session.query(QGEP.wastewater_node)
     if filtered:
-        query = query.filter(QGEP.wastewater_networkelement.obj_id.in_(subset_ids))
+        # 12.12.2022
+        # filtering on fk_wastewater_structure.in_(subset_ids) to get all wastewater_nodes
+        # query = query.filter(QGEP.wastewater_networkelement.obj_id.in_(subset_ids))
+        query = query.filter(QGEP.wastewater_networkelement.fk_wastewater_structure.in_(wws_ids))
+        
     for row in query:
 
         # AVAILABLE FIELDS IN QGEP.wastewater_node


### PR DESCRIPTION
- filtering on fk_wastewater_structures instead of selected wastewater_nodes:
  - replaced query = query.filter(QGEP.wastewater_networkelement.obj_id.in_(subset_ids)) with
        query = query.filter(QGEP.wastewater_networkelement.fk_wastewater_structure.in_(wws_ids))
- to be able to do that qgep_export needs new argument selection2 with the obj_id's of the selected elements from vw_gep_wastewater_structure
- this needs a new function def selected_wws(self) in gui_export.py
- adapting the qgep_export call in _init_.py: qgep_export(selection=export_dialog.selected_ids, selection2=export_dialog.selected_wws, labels_file=labels_file_path)