### PR TITLE
omit empty pg connection settings

### DIFF
--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -45,7 +45,7 @@ def show_success(title, message, log_path):
 import_dialog = None
 
 
-def action_import(plugin, pgservice=None):
+def action_import(plugin):
     """
     Is executed when the user clicks the importAction tool
     """
@@ -53,9 +53,6 @@ def action_import(plugin, pgservice=None):
 
     if not configure_from_modelbaker(plugin.iface):
         return
-
-    if pgservice:
-        config.PGSERVICE = pgservice
 
     default_folder = QgsSettings().value("qgep_pluging/last_interlis_path", QgsProject.instance().absolutePath())
     file_name, _ = QFileDialog.getOpenFileName(
@@ -153,16 +150,13 @@ def action_import(plugin, pgservice=None):
         )
 
 
-def action_export(plugin, pgservice=None):
+def action_export(plugin):
     """
     Is executed when the user clicks the exportAction tool
     """
 
     if not configure_from_modelbaker(plugin.iface):
         return
-
-    if pgservice:
-        config.PGSERVICE = pgservice
 
     export_dialog = GuiExport(plugin.iface.mainWindow())
 

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -4,17 +4,13 @@ import psycopg2
 from sqlalchemy.ext.automap import AutomapBase
 
 from .. import config
-from .various import exec_, get_pgconf, logger
+from .various import exec_, get_pgconf_as_ili_args, get_pgconf_as_psycopg2_dsn, logger
 
 
 def create_ili_schema(schema, model, log_path, recreate_schema=False):
     logger.info("CONNECTING TO DATABASE...")
 
-    pgconf = get_pgconf()
-
-    connection = psycopg2.connect(
-        f"host={pgconf['host']} port={pgconf['port']} dbname={pgconf['dbname']} user={pgconf['user']} password={pgconf['password']}"
-    )
+    connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
     connection.set_session(autocommit=True)
     cursor = connection.cursor()
 
@@ -36,9 +32,32 @@ def create_ili_schema(schema, model, log_path, recreate_schema=False):
     connection.close()
 
     logger.info(f"ILIDB SCHEMAIMPORT INTO {schema}...")
-    pgconf = get_pgconf()
     exec_(
-        f'"{config.JAVA}" -jar "{config.ILI2PG}" --schemaimport --dbhost {pgconf["host"]} --dbport {pgconf["port"]} --dbusr {pgconf["user"]} --dbpwd {pgconf["password"]} --dbdatabase {pgconf["dbname"]} --dbschema {schema} --setupPgExt --createGeomIdx --createFk --createFkIdx --createTidCol --importTid --noSmartMapping --defaultSrsCode 2056 --log "{log_path}" --nameLang de {model}'
+        " ".join(
+            [
+                f'"{config.JAVA}"',
+                "-jar",
+                f'"{config.ILI2PG}"',
+                "--schemaimport",
+                *get_pgconf_as_ili_args(),
+                "--dbschema",
+                f"{schema}",
+                "--setupPgExt",
+                "--createGeomIdx",
+                "--createFk",
+                "--createFkIdx",
+                "--createTidCol",
+                "--importTid",
+                "--noSmartMapping",
+                "--defaultSrsCode",
+                "2056",
+                "--log",
+                f'"{log_path}"',
+                "--nameLang",
+                "de",
+                f"{model}",
+            ]
+        )
     )
 
 
@@ -51,17 +70,61 @@ def validate_xtf_data(xtf_file, log_path):
 
 def import_xtf_data(schema, xtf_file, log_path):
     logger.info("IMPORTING XTF DATA...")
-    pgconf = get_pgconf()
     exec_(
-        f'"{config.JAVA}" -jar "{config.ILI2PG}" --import --deleteData --dbhost {pgconf["host"]} --dbport {pgconf["port"]} --dbusr {pgconf["user"]} --dbpwd {pgconf["password"]} --dbdatabase {pgconf["dbname"]} --dbschema {schema} --modeldir "{config.ILI_FOLDER}" --disableValidation --skipReferenceErrors --createTidCol --noSmartMapping --defaultSrsCode 2056 --log "{log_path}" "{xtf_file}"'
+        " ".join(
+            [
+                f'"{config.JAVA}"',
+                "-jar",
+                f'"{config.ILI2PG}"',
+                "--import",
+                "--deleteData",
+                *get_pgconf_as_ili_args(),
+                "--dbschema",
+                f'"{schema}"',
+                "--modeldir",
+                f'"{config.ILI_FOLDER}"',
+                "--disableValidation",
+                "--skipReferenceErrors",
+                "--createTidCol",
+                "--noSmartMapping",
+                "--defaultSrsCode",
+                "2056",
+                "--log",
+                f'"{log_path}"',
+                f'"{xtf_file}"',
+            ]
+        )
     )
 
 
 def export_xtf_data(schema, model_name, xtf_file, log_path):
     logger.info("EXPORT ILIDB...")
-    pgconf = get_pgconf()
     exec_(
-        f'"{config.JAVA}" -jar "{config.ILI2PG}" --export --models {model_name} --dbhost {pgconf["host"]} --dbport {pgconf["port"]} --dbusr {pgconf["user"]} --dbpwd {pgconf["password"]} --dbdatabase {pgconf["dbname"]} --dbschema {schema} --modeldir "{config.ILI_FOLDER}" --disableValidation --skipReferenceErrors --createTidCol --noSmartMapping --defaultSrsCode 2056 --log "{log_path}" --trace "{xtf_file}"'
+        " ".join(
+            [
+                f'"{config.JAVA}"',
+                "-jar",
+                f'"{config.ILI2PG}"',
+                "--export",
+                "--models",
+                f"{model_name}",
+                *get_pgconf_as_ili_args(),
+                "--dbschema",
+                f"{schema}",
+                "--modeldir",
+                f'"{config.ILI_FOLDER}"',
+                "--disableValidation",
+                "--skipReferenceErrors",
+                "--createTidCol",
+                "--noSmartMapping",
+                "--defaultSrsCode",
+                "2056",
+                "--log",
+                f'"{log_path}"',
+                "--trace",
+                f'"{xtf_file}"',
+            ]
+        )
     )
 
 

--- a/qgepqwat2ili/utils/various.py
+++ b/qgepqwat2ili/utils/various.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import tempfile
 import time
+from typing import List
 
 from .. import config
 
@@ -220,6 +221,41 @@ def get_pgconf():
         pgconf["password"] = config.PGPASS
 
     return collections.defaultdict(str, pgconf)
+
+
+def get_pgconf_as_psycopg2_dsn() -> List[str]:
+    """Returns the pgconf as a psycopg2 connection string"""
+
+    pgconf = get_pgconf()
+    parts = []
+    if pgconf["host"]:
+        parts.append(f"host={pgconf['host']}")
+    if pgconf["port"]:
+        parts.append(f"port={pgconf['port']}")
+    if pgconf["user"]:
+        parts.append(f"dbname={pgconf['dbname']}")
+    if pgconf["password"]:
+        parts.append(f"user={pgconf['user']}")
+    if pgconf["dbname"]:
+        parts.append(f"password={pgconf['password']}")
+    return " ".join(parts)
+
+
+def get_pgconf_as_ili_args() -> List[str]:
+    """Returns the pgconf as a list of ili2db arguments"""
+    pgconf = get_pgconf()
+    args = []
+    if pgconf["host"]:
+        args.extend(["--dbhost", '"' + pgconf["host"] + '"'])
+    if pgconf["port"]:
+        args.extend(["--dbport", '"' + pgconf["port"] + '"'])
+    if pgconf["user"]:
+        args.extend(["--dbusr", '"' + pgconf["user"] + '"'])
+    if pgconf["password"]:
+        args.extend(["--dbpwd", '"' + pgconf["password"] + '"'])
+    if pgconf["dbname"]:
+        args.extend(["--dbdatabase", '"' + pgconf["dbname"] + '"'])
+    return args
 
 
 def make_log_path(next_to_path, step_name):


### PR DESCRIPTION
This improves the way postgres connection settings are generated, to omit empty parameters both in psycopg connections and ili2db CLI.
Hopefully fixes https://github.com/QGEP/QGEP/issues/725