### PR TITLE
fix #53: add a check for the datamodel version

### DIFF
--- a/qgepqwat2ili/__init__.py
+++ b/qgepqwat2ili/__init__.py
@@ -8,12 +8,14 @@ from .qgep.import_ import qgep_import
 from .qgep.mapping import get_qgep_mapping
 from .qgep.model_abwasser import Base as BaseAbwasser
 from .qgep.model_qgep import Base as BaseQgep
+from .qgep.version import QGEP_PUM_TABLE, QGEP_SUPPORTED_VERSION
 from .qwat.export import qwat_export
 from .qwat.import_ import qwat_import
 from .qwat.mapping import get_qwat_mapping
 from .qwat.model_qwat import Base as BaseQwat
 from .qwat.model_wasser import Base as BaseWasser
-from .utils.various import make_log_path
+from .qwat.version import QWAT_PUM_TABLE, QWAT_SUPPORTED_VERSION
+from .utils.various import check_version, make_log_path
 
 
 def main(args):
@@ -21,6 +23,7 @@ def main(args):
     parser = argparse.ArgumentParser(
         description="ili2QWAT / ili2QGEP entrypoint", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
+    parser.add_argument("--skip_version_check", action="store_true", help="do not check the datamodel version")
 
     subparsers = parser.add_subparsers(title="subcommands", dest="parser")
     # subparsers.required = True
@@ -130,6 +133,10 @@ def main(args):
         SCHEMA = config.ABWASSER_SCHEMA
         ILI_MODEL = config.ABWASSER_ILI_MODEL
         ILI_MODEL_NAME = config.ABWASSER_ILI_MODEL_NAME
+
+        if not args.skip_version_check:
+            check_version(QGEP_PUM_TABLE, QGEP_SUPPORTED_VERSION)
+
         if args.direction == "export":
             utils.ili2db.create_ili_schema(
                 SCHEMA, ILI_MODEL, make_log_path(log_path, "ilicreate"), recreate_schema=args.recreate_schema
@@ -164,6 +171,11 @@ def main(args):
         SCHEMA = config.WASSER_SCHEMA
         ILI_MODEL = config.WASSER_ILI_MODEL
         ILI_MODEL_NAME = config.WASSER_ILI_MODEL_NAME
+
+        if not args.skip_version_check:
+            # note: there are two tables, info and upgrades, not sure which one is used
+            check_version(QWAT_PUM_TABLE, QWAT_SUPPORTED_VERSION)
+
         if args.direction == "export":
             utils.ili2db.create_ili_schema(
                 SCHEMA, ILI_MODEL, make_log_path(log_path, "ilicreate"), recreate_schema=args.recreate_schema

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -15,13 +15,20 @@ from ....utils.qgeplayermanager import QgepLayerManager
 from .. import config
 from ..qgep.export import qgep_export
 from ..qgep.import_ import qgep_import
+from ..qgep.version import QGEP_PUM_TABLE, QGEP_SUPPORTED_VERSION
 from ..utils.ili2db import (
     create_ili_schema,
     export_xtf_data,
     import_xtf_data,
     validate_xtf_data,
 )
-from ..utils.various import CmdException, LoggingHandlerContext, logger, make_log_path
+from ..utils.various import (
+    CmdException,
+    LoggingHandlerContext,
+    check_version,
+    logger,
+    make_log_path,
+)
 from .gui_export import GuiExport
 from .gui_import import GuiImport
 
@@ -54,6 +61,9 @@ def action_import(plugin):
 
     if not configure_from_modelbaker(plugin.iface):
         return
+
+    # check version
+    check_version(QGEP_PUM_TABLE, QGEP_SUPPORTED_VERSION)
 
     default_folder = QgsSettings().value("qgep_pluging/last_interlis_path", QgsProject.instance().absolutePath())
     file_name, _ = QFileDialog.getOpenFileName(
@@ -158,6 +168,9 @@ def action_export(plugin):
 
     if not configure_from_modelbaker(plugin.iface):
         return
+
+    # check version
+    check_version(QGEP_PUM_TABLE, QGEP_SUPPORTED_VERSION)
 
     export_dialog = GuiExport(plugin.iface.mainWindow())
 

--- a/qgepqwat2ili/qgep/version.py
+++ b/qgepqwat2ili/qgep/version.py
@@ -1,0 +1,2 @@
+QGEP_PUM_TABLE = "qgep_sys.pum_info"
+QGEP_SUPPORTED_VERSION = ">=1.5.7"  # see https://peps.python.org/pep-0440/#version-specifiers

--- a/qgepqwat2ili/qwat/version.py
+++ b/qgepqwat2ili/qwat/version.py
@@ -1,0 +1,2 @@
+QWAT_PUM_TABLE = "qwat_sys.info"  # note: in the demo data, there's also an "upgrades" table ?!
+QWAT_SUPPORTED_VERSION = ">=1.3.6"  # see https://peps.python.org/pep-0440/#version-specifiers


### PR DESCRIPTION
this is currently expected to fail for QGEP, as in the CI, it uses the 1.5.6 release, while we'll have to target >=1.5.7 (at least because of https://github.com/QGEP/qgepqwat2ili/pull/101, but probably other changes as well)