### PR TITLE
Fix layout warning because of unsused spacer

### DIFF
--- a/qgepqwat2ili/gui/gui_export.ui
+++ b/qgepqwat2ili/gui/gui_export.ui
@@ -61,19 +61,6 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-    </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
The unused spacer was in the same layout position of another widget