### PR TITLE
20230-08-fix-Change TextVAli is Bottom, not Top

### DIFF
--- a/qgepqwat2ili/qgep/export.py
+++ b/qgepqwat2ili/qgep/export.py
@@ -191,7 +191,7 @@ def qgep_export(selection=None, labels_file=None):
             ),
             "textori": modulo_angle(row["properties"]["LabelRotation"]),
             "texthali": "Left",  # can be Left/Center/Right
-            "textvali": "Top",  # can be Top,Cap,Half,Base,Bottom
+            "textvali": "Bottom",  # can be Top,Cap,Half,Base,Bottom
             # --- SIA405_TextPos ---
             "plantyp": row["properties"]["scale"],
             "textinhalt": row["properties"]["LabelText"],


### PR DESCRIPTION
Interlisexport: TextVAli is Bottom, not Top - should solve https://github.com/QGEP/QGEP/issues/832