### PR TITLE
2024-08-02-fix-postimport

### DIFF
--- a/qgepqwat2ili/postimport.py
+++ b/qgepqwat2ili/postimport.py
@@ -48,8 +48,9 @@ def qgep_postimport():
     logger.info("update_wastewater_structure_label for all datasets - please be patient")
     post_session.execute("SELECT qgep_od.update_wastewater_structure_label(NULL, True);")
     logger.info("update_wastewater_node_symbology for all datasets - please be patient")
-    logger.info("update_wn_symbology_by_overflow for all datasets - please be patient")
-    post_session.execute("SELECT qgep_od.update_wn_symbology_by_overflow(NULL, True);")
+    # update_wastewater_structure_symbology instead of update_wn_symbology_by_overflow (tww)
+    logger.info("update_wastewater_structure_symbology for all datasets - please be patient")
+    post_session.execute("SELECT qgep_od.update_wastewater_structure_symbology(NULL, True);")
 
 
     logger.info("Refresh materialized views")

--- a/qgepqwat2ili/qgepdss/export.py
+++ b/qgepqwat2ili/qgepdss/export.py
@@ -591,7 +591,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
             bezeichnung=null_to_emptystr(row.identifier),
             grundwasserleiterref=get_tid(row.fk_aquifier__REL),
             lage=ST_Force2D(row.situation_geometry),
-            oberflaechengewaesserref=get_tid(row.fk_surface_water_body__REL),
+            oberflaechengewaesserref=get_tid(row.fk_surface_water_bodies__REL),
         )
         abwasser_session.add(wasserfassung)
         create_metaattributes(row)
@@ -702,7 +702,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
             bwg_code=row.code_bwg,
             kilomo=row.km_down,
             kilomu=row.km_up,
-            oberflaechengewaesserref=get_tid(row.fk_surface_water_body__REL),
+            oberflaechengewaesserref=get_tid(row.fk_surface_water_bodies__REL),
             reflaenge=row.ref_length,
             verlauf=ST_Force2D(row.progression_geometry),
             # reference to own class not supported in qgep
@@ -1949,7 +1949,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
             bemerkung=truncate(emptystr_to_null(row.remark), 80),
             bezeichnung=null_to_emptystr(row.identifier),
             lage=ST_Force2D(row.situation_geometry),
-            oberflaechengewaesserref=get_tid(row.fk_surface_water_body__REL),
+            oberflaechengewaesserref=get_tid(row.fk_surface_water_bodies__REL),
         )
         abwasser_session.add(badestelle)
         create_metaattributes(row)

--- a/qgepqwat2ili/qgepdss/export.py
+++ b/qgepqwat2ili/qgepdss/export.py
@@ -3149,7 +3149,8 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
             **base_common(row, "messreihe"),
             # --- messreihe ---
 
-            abwassernetzelementref=get_tid(row.fk_wastewater_networkelement__REL),
+            # not supported in qgep - will be introduced with VSA-DSS 2020
+            # abwassernetzelementref=get_tid(row.fk_wastewater_networkelement__REL),
             art=get_vl(row.kind__REL),
             bemerkung=truncate(emptystr_to_null(row.remark), 80),
             bezeichnung=null_to_emptystr(row.identifier),

--- a/qgepqwat2ili/qgepdss/export.py
+++ b/qgepqwat2ili/qgepdss/export.py
@@ -3063,7 +3063,8 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
             bezeichnung=null_to_emptystr(row.identifier),
             gewaesserabschnittref=get_tid(row.fk_water_course_segment__REL),
             lage=ST_Force2D(row.situation_geometry),
-            referenzstelleref=get_tid(row.fk_reference_station__REL),
+            # not supported in qgep datamodel yet, reference on same class
+            # referenzstelleref=get_tid(row.fk_reference_station__REL),
             staukoerper=get_vl(row.damming_device__REL),
             zweck=get_vl(row.purpose__REL),
         )


### PR DESCRIPTION
![20240802_postimport_error](https://github.com/user-attachments/assets/6d4c6203-ca70-4f59-973b-90f7e5858493)

update_wastewater_structure_symbology instead of update_wn_symbology_ by_overflow (tww)

other name in qgep - adaption was made on this in tww (correct mistake on backpoting from tww)