### PR TITLE
Update Model Baker iliwrapper path

### DIFF
--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -9,7 +9,7 @@ from qgis import processing
 from qgis.core import Qgis, QgsProject, QgsSettings
 from qgis.PyQt.QtWidgets import QApplication, QFileDialog, QProgressDialog, QPushButton
 from qgis.utils import iface, plugins
-from QgisModelBaker.libili2db import globals, ili2dbconfig, ili2dbutils
+from QgisModelBaker.libs.modelbaker.iliwrapper import globals, ili2dbconfig, ili2dbutils
 
 from ....utils.qgeplayermanager import QgepLayerManager
 from .. import config


### PR DESCRIPTION
With this modification current versions of the Model Baker plugin can be used.

> [!NOTE]
> The dependency to the Model Baker plugin (plugin not library) remain in opposite of what we did for TWW with incorporated modelbaker library. Future versions of the plugin could potentially break this again (but no changes in this direction are planned yet).