### PR TITLE
2024 10 02 addcheck mandatory fk owner fk_operator fk_dataowner fk_provider fix missing references

### DIFF
--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -489,9 +489,9 @@ def action_export(plugin):
 
         # 4. relation check check_fk_owner_null
         if flag_test:
-            check_fk_owner_null = False
-            check_fk_owner_null = check_fk_owner_null()
-            if check_fk_owner_null:
+            check_fk_owner = False
+            check_fk_owner = check_fk_owner_null()
+            if check_fk_owner:
                 print("OK: Integrity checks fk_owner not isNull")
                 show_success(
                     "Sucess",
@@ -511,9 +511,9 @@ def action_export(plugin):
                 # return
 
             # 5. relation check check_fk_operator_null
-            check_fk_operator_null = False
-            check_fk_operator_null = check_fk_operator_null()
-            if check_fk_operator_null:
+            check_fk_operator = False
+            check_fk_operator = check_fk_operator_null()
+            if check_fk_operator:
                 print("OK: Integrity checks fk_operator not isNull")
                 show_success(
                     "Sucess",
@@ -534,9 +534,9 @@ def action_export(plugin):
 
         # 6. relation check check_fk_dataowner_null
         if flag_test:
-            check_fk_dataowner_null = False
-            check_fk_dataowner_null = check_fk_dataowner_null()
-            if check_fk_dataowner_null:
+            check_fk_dataowner = False
+            check_fk_dataowner = check_fk_dataowner_null()
+            if check_fk_dataowner:
                 print("OK: Integrity checks fk_dataowner not isNull")
                 show_success(
                     "Sucess",
@@ -556,9 +556,9 @@ def action_export(plugin):
                 # return
 
             # 6. relation check check_fk_provider_null
-            check_fk_provider_null = False
-            check_fk_provider_null = check_fk_provider_null()
-            if check_fk_provider_null:
+            check_fk_provider = False
+            check_fk_provider = check_fk_provider_null()
+            if check_fk_provider:
                 print("OK: Integrity checks fk_provider not isNull")
                 show_success(
                     "Sucess",

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -462,114 +462,117 @@ def action_export(plugin):
                 return
 
         # 3. identifier check check_identifier_null
-        check_identifier = False
-        check_identifier = check_identifier_null()
-        if check_identifier:
-            print("OK: Integrity checks identifiers not isNull")
-            show_success(
-                "Sucess",
-                "OK: Integrity checks identifiers not isNull",
-                None,
-            )
+        if flag_test:
+            check_identifier = False
+            check_identifier = check_identifier_null()
+            if check_identifier:
+                print("OK: Integrity checks identifiers not isNull")
+                show_success(
+                    "Sucess",
+                    "OK: Integrity checks identifiers not isNull",
+                    None,
+                )
 
-        else:
-            progress_dialog.close()
-            print("INFO: missing identifiers")
-            show_hint(
-                "INFO: Missing identifiers in schema qgep_od",
-                "Add missing identifiers to get a valid INTERLIS export file. See qgep logs tab for details.",
-                None,
-            )
-            # just show hint, but continue
-            # return
+            else:
+                progress_dialog.close()
+                print("INFO: missing identifiers")
+                show_hint(
+                    "INFO: Missing identifiers in schema qgep_od",
+                    "Add missing identifiers to get a valid INTERLIS export file. See qgep logs tab for details.",
+                    None,
+                )
+                # just show hint, but continue
+                # return
 
         # 4. relation check check_fk_owner_null
-        check_fk_owner_null = False
-        check_fk_owner_null = check_fk_owner_null()
-        if check_fk_owner_null:
-            print("OK: Integrity checks fk_owner not isNull")
-            show_success(
-                "Sucess",
-                "OK: Integrity checks fk_owner not isNull",
-                None,
-            )
+        if flag_test:
+            check_fk_owner_null = False
+            check_fk_owner_null = check_fk_owner_null()
+            if check_fk_owner_null:
+                print("OK: Integrity checks fk_owner not isNull")
+                show_success(
+                    "Sucess",
+                    "OK: Integrity checks fk_owner not isNull",
+                    None,
+                )
 
-        else:
-            progress_dialog.close()
-            print("INFO: missing MANDATORY fk_owner")
-            show_hint(
-                "INFO: Missing MANDATORY fk_owner in schema qgep_od",
-                "Add missing MANDATORY fk_owner to get a valid INTERLIS export file. See qgep logs tab for details.",
-                None,
-            )
-            # just show hint, but continue
-            # return
+            else:
+                progress_dialog.close()
+                print("INFO: missing MANDATORY fk_owner")
+                show_hint(
+                    "INFO: Missing MANDATORY fk_owner in schema qgep_od",
+                    "Add missing MANDATORY fk_owner to get a valid INTERLIS export file. See qgep logs tab for details.",
+                    None,
+                )
+                # just show hint, but continue
+                # return
 
-        # 5. relation check check_fk_operator_null
-        check_fk_operator_null = False
-        check_fk_operator_null = check_fk_operator_null()
-        if check_fk_operator_null:
-            print("OK: Integrity checks fk_operator not isNull")
-            show_success(
-                "Sucess",
-                "OK: Integrity checks fk_operator not isNull",
-                None,
-            )
+            # 5. relation check check_fk_operator_null
+            check_fk_operator_null = False
+            check_fk_operator_null = check_fk_operator_null()
+            if check_fk_operator_null:
+                print("OK: Integrity checks fk_operator not isNull")
+                show_success(
+                    "Sucess",
+                    "OK: Integrity checks fk_operator not isNull",
+                    None,
+                )
 
-        else:
-            progress_dialog.close()
-            print("INFO: missing MANDATORY fk_operator")
-            show_hint(
-                "INFO: Missing MANDATORY fk_operator in schema qgep_od",
-                "Add missing MANDATORY fk_operator to get a valid INTERLIS export file. See qgep logs tab for details.",
-                None,
-            )
-            # just show hint, but continue
-            # return
+            else:
+                progress_dialog.close()
+                print("INFO: missing MANDATORY fk_operator")
+                show_hint(
+                    "INFO: Missing MANDATORY fk_operator in schema qgep_od",
+                    "Add missing MANDATORY fk_operator to get a valid INTERLIS export file. See qgep logs tab for details.",
+                    None,
+                )
+                # just show hint, but continue
+                # return
 
         # 6. relation check check_fk_dataowner_null
-        check_fk_dataowner_null = False
-        check_fk_dataowner_null = check_fk_dataowner_null()
-        if check_fk_dataowner_null:
-            print("OK: Integrity checks fk_dataowner not isNull")
-            show_success(
-                "Sucess",
-                "OK: Integrity checks fk_dataowner not isNull",
-                None,
-            )
+        if flag_test:
+            check_fk_dataowner_null = False
+            check_fk_dataowner_null = check_fk_dataowner_null()
+            if check_fk_dataowner_null:
+                print("OK: Integrity checks fk_dataowner not isNull")
+                show_success(
+                    "Sucess",
+                    "OK: Integrity checks fk_dataowner not isNull",
+                    None,
+                )
 
-        else:
-            progress_dialog.close()
-            print("INFO: missing fk_dataowner")
-            show_hint(
-                "INFO: Missing fk_dataowner in schema qgep_od",
-                "Add missing fk_dataowner to get a valid INTERLIS export file when converting to Release 2020 (will bei MANDATORY). See qgep logs tab for details.",
-                None,
-            )
-            # just show hint, but continue
-            # return
+            else:
+                progress_dialog.close()
+                print("INFO: missing fk_dataowner")
+                show_hint(
+                    "INFO: Missing fk_dataowner in schema qgep_od",
+                    "Add missing fk_dataowner to get a valid INTERLIS export file when converting to Release 2020 (will bei MANDATORY). See qgep logs tab for details.",
+                    None,
+                )
+                # just show hint, but continue
+                # return
 
-        # 6. relation check check_fk_provider_null
-        check_fk_provider_null = False
-        check_fk_provider_null = check_fk_provider_null()
-        if check_fk_provider_null:
-            print("OK: Integrity checks fk_provider not isNull")
-            show_success(
-                "Sucess",
-                "OK: Integrity checks fk_provider not isNull",
-                None,
-            )
+            # 6. relation check check_fk_provider_null
+            check_fk_provider_null = False
+            check_fk_provider_null = check_fk_provider_null()
+            if check_fk_provider_null:
+                print("OK: Integrity checks fk_provider not isNull")
+                show_success(
+                    "Sucess",
+                    "OK: Integrity checks fk_provider not isNull",
+                    None,
+                )
 
-        else:
-            progress_dialog.close()
-            print("INFO: missing fk_provider")
-            show_hint(
-                "INFO: Missing fk_provider in schema qgep_od",
-                "Add missing fk_provider to get a valid INTERLIS export file when converting to Release 2020 (will bei MANDATORY). See qgep logs tab for details.",
-                None,
-            )
-            # just show hint, but continue
-            # return
+            else:
+                progress_dialog.close()
+                print("INFO: missing fk_provider")
+                show_hint(
+                    "INFO: Missing fk_provider in schema qgep_od",
+                    "Add missing fk_provider to get a valid INTERLIS export file when converting to Release 2020 (will bei MANDATORY). See qgep logs tab for details.",
+                    None,
+                )
+                # just show hint, but continue
+                # return
 
         # Prepare the temporary ili2pg model
         progress_dialog.setLabelText("Creating ili schema..." + emodel)

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -501,9 +501,9 @@ def action_export(plugin):
 
             else:
                 progress_dialog.close()
-                print("INFO: missing MANDATORY fk_owner")
+                print("ERROR: missing MANDATORY fk_owner")
                 show_hint(
-                    "INFO: Missing MANDATORY fk_owner in schema qgep_od",
+                    "ERROR: Missing MANDATORY fk_owner in schema qgep_od",
                     "Add missing MANDATORY fk_owner to get a valid INTERLIS export file. See qgep logs tab for details.",
                     None,
                 )
@@ -523,9 +523,9 @@ def action_export(plugin):
 
             else:
                 progress_dialog.close()
-                print("INFO: missing MANDATORY fk_operator")
+                print("ERROR: missing MANDATORY fk_operator")
                 show_hint(
-                    "INFO: Missing MANDATORY fk_operator in schema qgep_od",
+                    "ERROR: Missing MANDATORY fk_operator in schema qgep_od",
                     "Add missing MANDATORY fk_operator to get a valid INTERLIS export file. See qgep logs tab for details.",
                     None,
                 )

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -483,7 +483,7 @@ def action_export(plugin):
             # just show hint, but continue
             # return
 
-        # 4. identifier check check_fk_owner_null
+        # 4. relation check check_fk_owner_null
         check_fk_owner_null = False
         check_fk_owner_null = check_fk_owner_null()
         if check_fk_owner_null:
@@ -505,7 +505,7 @@ def action_export(plugin):
             # just show hint, but continue
             # return
 
-        # 5. identifier check check_fk_operator_null
+        # 5. relation check check_fk_operator_null
         check_fk_operator_null = False
         check_fk_operator_null = check_fk_operator_null()
         if check_fk_operator_null:
@@ -526,7 +526,52 @@ def action_export(plugin):
             )
             # just show hint, but continue
             # return
-            
+
+        # 6. relation check check_fk_dataowner_null
+        check_fk_dataowner_null = False
+        check_fk_dataowner_null = check_fk_dataowner_null()
+        if check_fk_dataowner_null:
+            print("OK: Integrity checks fk_dataowner not isNull")
+            show_success(
+                "Sucess",
+                "OK: Integrity checks fk_dataowner not isNull",
+                None,
+            )
+
+        else:
+            progress_dialog.close()
+            print("INFO: missing fk_dataowner")
+            show_hint(
+                "INFO: Missing fk_dataowner in schema qgep_od",
+                "Add missing fk_dataowner to get a valid INTERLIS export file when converting to Release 2020 (will bei MANDATORY). See qgep logs tab for details.",
+                None,
+            )
+            # just show hint, but continue
+            # return
+
+       # 6. relation check check_fk_provider_null
+        check_fk_provider_null = False
+        check_fk_provider_null = check_fk_provider_null()
+        if check_fk_provider_null:
+            print("OK: Integrity checks fk_provider not isNull")
+            show_success(
+                "Sucess",
+                "OK: Integrity checks fk_provider not isNull",
+                None,
+            )
+
+        else:
+            progress_dialog.close()
+            print("INFO: missing fk_provider")
+            show_hint(
+                "INFO: Missing fk_provider in schema qgep_od",
+                "Add missing fk_provider to get a valid INTERLIS export file when converting to Release 2020 (will bei MANDATORY). See qgep logs tab for details.",
+                None,
+            )
+            # just show hint, but continue
+            # return
+
+
         # Prepare the temporary ili2pg model
         progress_dialog.setLabelText("Creating ili schema..." + emodel)
 

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -505,6 +505,28 @@ def action_export(plugin):
             # just show hint, but continue
             # return
 
+        # 5. identifier check check_fk_operator_null
+        check_fk_operator_null = False
+        check_fk_operator_null = check_fk_operator_null()
+        if check_fk_operator_null:
+            print("OK: Integrity checks fk_operator not isNull")
+            show_success(
+                "Sucess",
+                "OK: Integrity checks fk_operator not isNull",
+                None,
+            )
+
+        else:
+            progress_dialog.close()
+            print("INFO: missing MANDATORY fk_operator")
+            show_hint(
+                "INFO: Missing MANDATORY fk_operator in schema qgep_od",
+                "Add missing MANDATORY fk_operator to get a valid INTERLIS export file. See qgep logs tab for details.",
+                None,
+            )
+            # just show hint, but continue
+            # return
+            
         # Prepare the temporary ili2pg model
         progress_dialog.setLabelText("Creating ili schema..." + emodel)
 

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -29,6 +29,10 @@ from ..qgepsia405.import_ import qgep_import as qgepsia405_import
 from ..utils.ili2db import (  # neu 22.7.2022; get_xtf_model,; neu 31.3.2023; neu 12.4.2023
     check_identifier_null,
     check_organisation_subclass_data,
+    check_fk_owner_null,
+    check_fk_operator_null,
+    check_fk_dataowner_null,
+    check_fk_provider_null,
     check_wastewater_structure_subclass_data,
     create_ili_schema,
     export_xtf_data,

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -507,8 +507,8 @@ def action_export(plugin):
                     "Add missing MANDATORY fk_owner to get a valid INTERLIS export file. See qgep logs tab for details.",
                     None,
                 )
-                # just show hint, but continue
-                # return
+                # make mandatory
+                return
 
             # 5. relation check check_fk_operator_null
             check_fk_operator = False
@@ -529,8 +529,8 @@ def action_export(plugin):
                     "Add missing MANDATORY fk_operator to get a valid INTERLIS export file. See qgep logs tab for details.",
                     None,
                 )
-                # just show hint, but continue
-                # return
+                # make mandatory
+                return
 
         # 6. relation check check_fk_dataowner_null
         if flag_test:

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -483,6 +483,28 @@ def action_export(plugin):
             # just show hint, but continue
             # return
 
+        # 4. identifier check check_fk_owner_null
+        check_fk_owner_null = False
+        check_fk_owner_null = check_fk_owner_null()
+        if check_fk_owner_null:
+            print("OK: Integrity checks fk_owner not isNull")
+            show_success(
+                "Sucess",
+                "OK: Integrity checks fk_owner not isNull",
+                None,
+            )
+
+        else:
+            progress_dialog.close()
+            print("INFO: missing MANDATORY fk_owner")
+            show_hint(
+                "INFO: Missing MANDATORY fk_owner in schema qgep_od",
+                "Add missing MANDATORY fk_owner to get a valid INTERLIS export file. See qgep logs tab for details.",
+                None,
+            )
+            # just show hint, but continue
+            # return
+
         # Prepare the temporary ili2pg model
         progress_dialog.setLabelText("Creating ili schema..." + emodel)
 

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -360,7 +360,7 @@ def action_import(plugin):
     # 31.5.2024 should not be needed anymore
     # progress_dialog.setLabelText("Set main_cover manually after import if vw_qgep_wastewater_structure does not display correctly!")
 
-    time.sleep(2)
+    # time.sleep(2)
     # to add option to run main_cover.sql manually - see postimport.py
 
     # 24.7.2022 / moved to end

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -102,7 +102,7 @@ def action_importc(plugin):
         progress_dialog.show()
         progress_dialog.setLabelText("waiting...")
         # delays the execution for 5.5 secs.
-        time.sleep(5.5)
+        # time.sleep(5.5)
         progress_dialog.close
         # end action_do_importc
 

--- a/qgepqwat2ili/gui/__init__.py
+++ b/qgepqwat2ili/gui/__init__.py
@@ -502,7 +502,7 @@ def action_export(plugin):
             else:
                 progress_dialog.close()
                 print("ERROR: missing MANDATORY fk_owner")
-                show_hint(
+                show_failure(
                     "ERROR: Missing MANDATORY fk_owner in schema qgep_od",
                     "Add missing MANDATORY fk_owner to get a valid INTERLIS export file. See qgep logs tab for details.",
                     None,
@@ -524,7 +524,7 @@ def action_export(plugin):
             else:
                 progress_dialog.close()
                 print("ERROR: missing MANDATORY fk_operator")
-                show_hint(
+                show_failure(
                     "ERROR: Missing MANDATORY fk_operator in schema qgep_od",
                     "Add missing MANDATORY fk_operator to get a valid INTERLIS export file. See qgep logs tab for details.",
                     None,

--- a/qgepqwat2ili/qgep/export.py
+++ b/qgepqwat2ili/qgep/export.py
@@ -102,7 +102,9 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
         if val is None:
             return None
         if len(val) > max_length:
-            logger.warning(f"Value '{val}' exceeds expected length ({max_length})", stacklevel=2)
+            # _log() got an unexpected keyword argument 'stacklevel'
+            #    logger.warning(f"Value '{val}' exceeds expected length ({max_length})", stacklevel=2)
+            logger.warning(f"Value '{val}' exceeds expected length ({max_length})")
         return val[0:max_length]
 
     def modulo_angle(val):

--- a/qgepqwat2ili/qgep/export.py
+++ b/qgepqwat2ili/qgep/export.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
 from .. import utils
+
 # 4.10.2024
 from ..utils.ili2db import skip_wwtp_structure_ids
 from ..utils.various import logger
@@ -46,6 +47,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     logger.info(
         f"wastewater_structure_id_sia405abwasser_list : {wastewater_structure_id_sia405abwasser_list}",
     )
+
     # Orientation
     oriented = orientation is not None
     if oriented:

--- a/qgepqwat2ili/qgep/export.py
+++ b/qgepqwat2ili/qgep/export.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
 from .. import utils
+# 4.10.2024
+from ..utils.ili2db import skip_wwtp_structure_ids
 from ..utils.various import logger
 from .model_abwasser import get_abwasser_model
 from .model_qgep import get_qgep_model
@@ -36,6 +38,14 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     filtered = selection is not None
     subset_ids = selection if selection is not None else []
 
+    # get list of id's of class wwtp_structure (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
+
+    wastewater_structure_id_sia405abwasser_list = None
+    wastewater_structure_id_sia405abwasser_list = skip_wwtp_structure_ids()
+
+    logger.info(
+        f"wastewater_structure_id_sia405abwasser_list : {wastewater_structure_id_sia405abwasser_list}",
+    )
     # Orientation
     oriented = orientation is not None
     if oriented:
@@ -211,7 +221,10 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
         """
 
         return {
-            "abwasserbauwerkref": get_tid(row.fk_wastewater_structure__REL),
+            # "abwasserbauwerkref": get_tid(row.fk_wastewater_structure__REL),
+            "abwasserbauwerkref": check_fk_in_subsetid(
+                wastewater_structure_id_sia405abwasser_list, row.fk_wastewater_structure__REL
+            ),
             "bemerkung": truncate(emptystr_to_null(row.remark), 80),
             "bezeichnung": null_to_emptystr(row.identifier),
         }

--- a/qgepqwat2ili/qgep/export.py
+++ b/qgepqwat2ili/qgep/export.py
@@ -130,10 +130,13 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
             logger.info(f"check_fk_in_subsetid - tid = '{tid_maker.tid_for_row(relation)}' ")
             return tid_maker.tid_for_row(relation)
         else:
-            logger.info(
-                f"check_fk_in_subsetid - '{fremdschluesselstr}' is not in subset - replaced with None instead!"
-            )
-            return None
+            if filtered:
+                logger.info(
+                    f"check_fk_in_subsetid - '{fremdschluesselstr}' is not in subset - replaced with None instead!"
+                )
+                return None
+            else:
+                return tid_maker.tid_for_row(relation)
 
     def create_metaattributes(row):
         metaattribute = ABWASSER.metaattribute(

--- a/qgepqwat2ili/qgepdss/export.py
+++ b/qgepqwat2ili/qgepdss/export.py
@@ -140,10 +140,13 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
             logger.info(f"check_fk_in_subsetid - tid = '{tid_maker.tid_for_row(relation)}' ")
             return tid_maker.tid_for_row(relation)
         else:
-            logger.info(
-                f"check_fk_in_subsetid - '{fremdschluesselstr}' is not in subset - replaced with None instead!"
-            )
-            return None
+            if filtered:
+                logger.info(
+                    f"check_fk_in_subsetid - '{fremdschluesselstr}' is not in subset - replaced with None instead!"
+                )
+                return None
+            else:
+                return tid_maker.tid_for_row(relation)
 
     def create_metaattributes(row):
         metaattribute = ABWASSER.metaattribute(

--- a/qgepqwat2ili/qgepdss/export.py
+++ b/qgepqwat2ili/qgepdss/export.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
 from .. import utils
+# 4.10.2024
+from ..utils.ili2db import skip_wwtp_structure_ids
 from ..utils.various import logger
 from .model_abwasser import get_abwasser_model
 from .model_qgep import get_qgep_model
@@ -42,6 +44,21 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
 
     # Logging for debugging
     logger.info(f"print subset_ids '{subset_ids}'")
+    
+   # get list of id's of class wwtp_structure (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
+                                               
+
+    wastewater_structure_id_sia405abwasser_list = None
+    wastewater_structure_id_sia405abwasser_list = skip_wwtp_structure_ids()
+
+    logger.info(
+        f"wastewater_structure_id_sia405abwasser_list : {wastewater_structure_id_sia405abwasser_list}",
+    )
+
+
+
+
+
 
     # Orientation
     oriented = orientation is not None

--- a/qgepqwat2ili/qgepdss/export.py
+++ b/qgepqwat2ili/qgepdss/export.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
 
 from .. import utils
+
 # 4.10.2024
 from ..utils.ili2db import skip_wwtp_structure_ids
 from ..utils.various import logger

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -61,6 +61,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
         """
         if relation is None:
             return None
+
         return tid_maker.tid_for_row(relation)
 
     def get_vl(relation):
@@ -102,7 +103,9 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
         if val is None:
             return None
         if len(val) > max_length:
-            logger.warning(f"Value '{val}' exceeds expected length ({max_length})", stacklevel=2)
+            # _log() got an unexpected keyword argument 'stacklevel'
+            #    logger.warning(f"Value '{val}' exceeds expected length ({max_length})", stacklevel=2)
+            logger.warning(f"Value '{val}' exceeds expected length ({max_length})")
         return val[0:max_length]
 
     def modulo_angle(val):

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -40,7 +40,8 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     subset_ids = selection if selection is not None else []
 
     # get list of id's of class wwtp_strucuture (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
-    get_wwtp_structure_ids()
+    wwtp_structure_ids = None
+    wwtp_structure_ids = get_wwtp_structure_ids()
     logger.info(
         "wwtp_structure_ids : {wwtp_structure_ids}",
     )

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -135,7 +135,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
                     f"check_fk_in_subsetid - '{fremdschluesselstr}' is not in subset - replaced with None instead!"
                 )
                 return None
-            else
+            else:
                 return tid_maker.tid_for_row(relation)
 
     def create_metaattributes(row):

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -130,10 +130,13 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
             logger.info(f"check_fk_in_subsetid - tid = '{tid_maker.tid_for_row(relation)}' ")
             return tid_maker.tid_for_row(relation)
         else:
-            logger.info(
-                f"check_fk_in_subsetid - '{fremdschluesselstr}' is not in subset - replaced with None instead!"
-            )
-            return None
+            if filtered:
+                logger.info(
+                    f"check_fk_in_subsetid - '{fremdschluesselstr}' is not in subset - replaced with None instead!"
+                )
+                return None
+            else
+                return tid_maker.tid_for_row(relation)
 
     def create_metaattributes(row):
         metaattribute = ABWASSER.metaattribute(

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -40,7 +40,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     subset_ids = selection if selection is not None else []
 
     # get list of id's of class wwtp_strucuture (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
-    wwtp_structure_ids = get_wwtp_structure_ids()
+    get_wwtp_structure_ids()
     logger.info(
         "wwtp_structure_ids : {wwtp_structure_ids}",
     )

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -48,7 +48,6 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
         f"wastewater_structure_id_sia405abwasser_list : {wastewater_structure_id_sia405abwasser_list}",
     )
 
-
     # Orientation
     oriented = orientation is not None
     if oriented:
@@ -222,7 +221,9 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
 
         return {
             # "abwasserbauwerkref": get_tid(row.fk_wastewater_structure__REL),
-            "abwasserbauwerkref": check_fk_in_subsetid(wastewater_structure_id_sia405abwasser_list, row.fk_wastewater_structure__REL),
+            "abwasserbauwerkref": check_fk_in_subsetid(
+                wastewater_structure_id_sia405abwasser_list, row.fk_wastewater_structure__REL
+            ),
             "bemerkung": truncate(emptystr_to_null(row.remark), 80),
             "bezeichnung": null_to_emptystr(row.identifier),
         }

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -36,6 +36,12 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     filtered = selection is not None
     subset_ids = selection if selection is not None else []
 
+    # get list of id's of class wwtp_strucuture (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
+    wwtp_structure_ids = get_wwtp_structure_ids()
+    logger.info(
+                "wwtp_structure_ids : {wwtp_structure_ids}",
+            )
+
     # Orientation
     oriented = orientation is not None
     if oriented:

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -7,6 +7,9 @@ from sqlalchemy.sql import text
 
 from .. import utils
 from ..utils.various import logger
+#4.10.2024
+from ..utils.ili2db import get_wwtp_structure_ids
+
 from .model_abwasser import get_abwasser_model
 from .model_qgep import get_qgep_model
 

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -40,7 +40,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     subset_ids = selection if selection is not None else []
 
     # get list of id's of class wwtp_strucuture (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
-    get_wwtp_structure_ids()
+    wwtp_structure_ids = get_wwtp_structure_ids()
     logger.info(
         "wwtp_structure_ids : {wwtp_structure_ids}",
     )

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -39,8 +39,9 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     filtered = selection is not None
     subset_ids = selection if selection is not None else []
 
-    # get list of id's of class wwtp_strucuture (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
-    get_wwtp_structure_ids()
+    # get list of id's of class wwtp_structure (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
+    wwtp_structure_ids = None
+    wwtp_structure_ids = get_wwtp_structure_ids()
     logger.info(
         "wwtp_structure_ids : {wwtp_structure_ids}",
     )

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -40,9 +40,10 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     subset_ids = selection if selection is not None else []
 
     # get list of id's of class wwtp_structure (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
-    get_wwtp_structure_ids()
+    wwtp_structure_id_list = None
+    wwtp_structure_id_list = get_wwtp_structure_ids()
     logger.info(
-        "wwtp_structure_ids : {wwtp_structure_ids}",
+        "wwtp_structure_id_list : {wwtp_structure_id_list}",
     )
 
     # Orientation

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -40,8 +40,7 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     subset_ids = selection if selection is not None else []
 
     # get list of id's of class wwtp_strucuture (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
-    wwtp_structure_ids = None
-    wwtp_structure_ids = get_wwtp_structure_ids()
+    get_wwtp_structure_ids()
     logger.info(
         "wwtp_structure_ids : {wwtp_structure_ids}",
     )

--- a/qgepqwat2ili/qgepsia405/export.py
+++ b/qgepqwat2ili/qgepsia405/export.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql import text
 from .. import utils
 
 # 4.10.2024
-from ..utils.ili2db import get_wwtp_structure_ids
+from ..utils.ili2db import skip_wwtp_structure_ids
 from ..utils.various import logger
 from .model_abwasser import get_abwasser_model
 from .model_qgep import get_qgep_model
@@ -40,11 +40,12 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
     subset_ids = selection if selection is not None else []
 
     # get list of id's of class wwtp_structure (ARABauwerk) to be able to check if fk_wastewater_structure references to wwtp_structure
-    wwtp_structure_id_list = None
-    wwtp_structure_id_list = get_wwtp_structure_ids()
+    wastewater_structure_id_sia405abwasser_list = None
+    wastewater_structure_id_sia405abwasser_list = skip_wwtp_structure_ids()
     logger.info(
-        "wwtp_structure_id_list : {wwtp_structure_id_list}",
+        f"wastewater_structure_id_sia405abwasser_list : {wastewater_structure_id_sia405abwasser_list}",
     )
+
 
     # Orientation
     oriented = orientation is not None
@@ -218,7 +219,8 @@ def qgep_export(selection=None, labels_file=None, orientation=None):
         """
 
         return {
-            "abwasserbauwerkref": get_tid(row.fk_wastewater_structure__REL),
+            # "abwasserbauwerkref": get_tid(row.fk_wastewater_structure__REL),
+            "abwasserbauwerkref": check_fk_in_subsetid(wastewater_structure_id_sia405abwasser_list, row.fk_wastewater_structure__REL),
             "bemerkung": truncate(emptystr_to_null(row.remark), 80),
             "bezeichnung": null_to_emptystr(row.identifier),
         }

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -469,7 +469,7 @@ def skip_wwtp_structure_ids():
 
     # select all obj_id from wastewater_structure that are not in wwtp_structure
     cursor.execute(
-        f"SELECT * FROM qgep_od.wastewater_structure WHERE obj_id NOT IN (SELECT obj_id FROM qgep_od.wwtp_structure);"
+        "SELECT * FROM qgep_od.wastewater_structure WHERE obj_id NOT IN (SELECT obj_id FROM qgep_od.wwtp_structure);"
     )
     # remove - only for testing
     # cursor.execute(

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -210,6 +210,44 @@ def check_fk_owner_null():
 
     return check_fk_owner_null
 
+# Checking if MAMDATORY eigentuemerref not is Null
+def check_fk_operator_null():
+
+    logger.info("INTEGRITY CHECK missing operator references fk_operator...")
+    print("INTEGRITY CHECK missing operator references fk_operator...")
+
+    connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
+    connection.set_session(autocommit=True)
+    cursor = connection.cursor()
+
+    missing_fk_operator_count = 0
+    for notsubclass in [
+        # SIA405 Abwasser
+        ("wastewater_structure"),
+    ]:
+        cursor.execute(
+            f"SELECT COUNT(obj_id) FROM qgep_od.{missing_fk_operator_count} WHERE fk_operator is null;"
+        )
+        # use cursor.fetchone()[0] instead of cursor.rowcount
+        logger.info(
+            f"Number of datasets in {notsubclass} without fk_operator : {cursor.fetchone()[0]}"
+        )
+
+        if cursor.fetchone() is None:
+            missing_fk_operator_count = missing_fk_operator_count
+        else:
+            missing_fk_operator_count = missing_fk_operator_count + int(cursor.fetchone()[0])
+
+    if missing_fk_operator_count == 0:
+        check_fk_operator_null = True
+        logger.info("OK: all mandatory fk_operator set in qgep_od!")
+    else:
+        missing_fk_operator_count = False
+        logger.info(f"ERROR: Missing mandatory fk_operator in qgep_od: {missing_fk_operator_count}")
+        print(f"ERROR: Missing mandatory fk_operator: {missing_fk_operator_count}")
+
+    return check_fk_operator_null
+    
 def create_ili_schema(schema, model, log_path, recreate_schema=False):
     logger.info("CONNECTING TO DATABASE...")
 

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -226,7 +226,7 @@ def check_fk_operator_null():
         ("wastewater_structure"),
     ]:
         cursor.execute(
-            f"SELECT COUNT(obj_id) FROM qgep_od.{missing_fk_operator_count} WHERE fk_operator is null;"
+            f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE fk_operator is null;"
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
         logger.info(

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -175,8 +175,8 @@ def check_identifier_null():
 # Checking if MAMDATORY eigentuemerref not is Null
 def check_fk_owner_null():
 
-    logger.info("INTEGRITY CHECK missing owner references fk_owner...")
-    print("INTEGRITY CHECK missing owner references fk_owner...")
+    logger.info("INTEGRITY CHECK missing MAMDATORY owner references fk_owner...")
+    print("INTEGRITY CHECK missing MAMDATORY owner references fk_owner...")
 
     connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
     connection.set_session(autocommit=True)
@@ -213,8 +213,8 @@ def check_fk_owner_null():
 # Checking if MAMDATORY eigentuemerref not is Null
 def check_fk_operator_null():
 
-    logger.info("INTEGRITY CHECK missing operator references fk_operator...")
-    print("INTEGRITY CHECK missing operator references fk_operator...")
+    logger.info("INTEGRITY CHECK missing MAMDATORY operator references fk_operator...")
+    print("INTEGRITY CHECK missing MAMDATORY operator references fk_operator...")
 
     connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
     connection.set_session(autocommit=True)
@@ -247,7 +247,84 @@ def check_fk_operator_null():
         print(f"ERROR: Missing mandatory fk_operator: {missing_fk_operator_count}")
 
     return check_fk_operator_null
-    
+
+# Checking if MAMDATORY datenherrref not is Null
+def check_fk_dataowner_null():
+
+    logger.info("INTEGRITY CHECK missing dataowner references fk_dataowner...")
+    print("INTEGRITY CHECK missing dataowner references fk_dataowner...")
+
+    connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
+    connection.set_session(autocommit=True)
+    cursor = connection.cursor()
+
+    missing_fk_dataowner_count = 0
+    for notsubclass in [
+        # VSA-KEK
+        ("file"),
+        ("data_media"),
+        ("maintenance_event"),
+        # SIA405 Abwasser
+        ("organisation"),
+        ("wastewater_structure"),
+        ("wastewater_networkelement"),
+        ("structure_part"),
+        ("reach_point"),
+        ("pipe_profile"),
+        # VSA-DSS
+        ("catchment_area"),
+        ("connection_object"),
+        ("control_center"),
+        ("hazard_source"),
+        ("hydr_geometry"),
+        ("hydraulic_char_data"),
+        ("measurement_result"),
+        ("measurement_series"),
+        ("measuring_device"),
+        ("measuring_point"),
+        ("mechanical_pretreatment"),
+        ("overflow"),
+        ("overflow_char"),
+        ("retention_body"),
+        ("river_bank"),
+        ("river_bed"),
+        ("sector_water_body"),
+        ("substance"),
+        ("surface_runoff_parameters"),
+        ("surface_water_bodies"),
+        ("throttle_shut_off_unit"),
+        ("waste_water_treatment"),
+        ("water_catchment"),
+        ("water_control_structure"),
+        ("water_course_segment"),
+        ("wwtp_energy_use"),
+        ("zone"),
+    ]:
+        cursor.execute(
+            f"SELECT COUNT(obj_id) FROM qgep_od.{missing_fk_dataowner_count} WHERE fk_dataowner is null;"
+        )
+        # use cursor.fetchone()[0] instead of cursor.rowcount
+        logger.info(
+            f"Number of datasets in {notsubclass} without fk_dataowner : {cursor.fetchone()[0]}"
+        )
+
+        if cursor.fetchone() is None:
+            missing_fk_dataowner_count = missing_fk_dataowner_count
+        else:
+            missing_fk_dataowner_count = missing_fk_dataowner_count + int(cursor.fetchone()[0])
+
+    if missing_fk_dataowner_count == 0:
+        check_fk_dataowner_null = True
+        logger.info("OK: all mandatory fk_dataowner set in qgep_od!")
+    else:
+        missing_fk_dataowner_count = False
+        logger.info(f"ERROR: Missing mandatory fk_dataowner in qgep_od: {missing_fk_dataowner_count}")
+        print(f"ERROR: Missing mandatory fk_dataowner: {missing_fk_dataowner_count}")
+
+    return check_fk_dataowner_null
+
+
+
 def create_ili_schema(schema, model, log_path, recreate_schema=False):
     logger.info("CONNECTING TO DATABASE...")
 

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -108,6 +108,7 @@ def check_identifier_null():
     cursor = connection.cursor()
 
     missing_identifier_count = 0
+    # add classes to be checked
     for notsubclass in [
         # VSA-KEK
         ("file"),
@@ -153,14 +154,23 @@ def check_identifier_null():
             f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE identifier is null;"
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
+        # add variable and store result of cursor.fetchone()[0] as the next call will give None value instead of count https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
+        class_identifier_count = int(cursor.fetchone()[0])
         logger.info(
-            f"Number of datasets in {notsubclass} without identifier : {cursor.fetchone()[0]}"
+            f"Number of datasets in {notsubclass} without fk_dataowner (tttt) : {class_identifier_count}"
         )
-
-        if cursor.fetchone() is None:
+        
+        #if cursor.fetchone() is None:
+        if class_identifier_count == 0:
             missing_identifier_count = missing_identifier_count
         else:
-            missing_identifier_count = missing_identifier_count + int(cursor.fetchone()[0])
+            #missing_identifier_count = missing_identifier_count + int(cursor.fetchone()[0])
+            missing_identifier_count = missing_identifier_count + class_identifier_count(cursor.fetchone()[0])
+
+        # add for testing 
+        logger.info(
+            f"missing_fk_dataowner_count : {missing_identifier_count}"
+        )
 
     if missing_identifier_count == 0:
         identifier_null_check = True
@@ -184,20 +194,28 @@ def check_fk_owner_null():
     cursor = connection.cursor()
 
     missing_fk_owner_count = 0
+    # add MANDATORY classes to be checked
     for notsubclass in [
         # SIA405 Abwasser
         ("wastewater_structure"),
     ]:
         cursor.execute(f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE fk_owner is null;")
         # use cursor.fetchone()[0] instead of cursor.rowcount
+        # add variable and store result of cursor.fetchone()[0] as the next call will give None value instead of count https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
+        class_fk_owner_count = int(cursor.fetchone()[0])
+        #logger.info(
+        #    f"Number of datasets in {notsubclass} without fk_owner : {cursor.fetchone()[0]}"
+        #)
         logger.info(
-            f"Number of datasets in {notsubclass} without fk_owner : {cursor.fetchone()[0]}"
+            f"Number of datasets in {notsubclass} without fk_owner (tttt) : {class_fk_owner_count}"
         )
 
-        if cursor.fetchone() is None:
+        #if cursor.fetchone() is None:
+        if class_fk_owner_count == 0:
             missing_fk_owner_count = missing_fk_owner_count
         else:
-            missing_fk_owner_count = missing_fk_owner_count + int(cursor.fetchone()[0])
+            #missing_fk_owner_count = missing_fk_owner_count + int(cursor.fetchone()[0])
+            missing_fk_owner_count = missing_fk_owner_count + class_fk_owner_count
 
         # add for testing 
         logger.info(
@@ -226,6 +244,8 @@ def check_fk_operator_null():
     cursor = connection.cursor()
 
     missing_fk_operator_count = 0
+
+    # add MANDATORY classes to be checked
     for notsubclass in [
         # SIA405 Abwasser
         ("wastewater_structure"),
@@ -271,6 +291,7 @@ def check_fk_dataowner_null():
     cursor = connection.cursor()
 
     missing_fk_dataowner_count = 0
+    # add MANDATORY classes to be checked
     for notsubclass in [
         # VSA-KEK
         ("file"),
@@ -316,23 +337,22 @@ def check_fk_dataowner_null():
             f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE fk_dataowner is null;"
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
-        
-        # hilfvariable
-        tttt = int(cursor.fetchone()[0])
+        # add variable and store result of cursor.fetchone()[0] as the next call will give None value instead of count https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
+        class_fk_dataowner_count = int(cursor.fetchone()[0])
         
         #logger.info(
         #    f"Number of datasets in {notsubclass} without fk_dataowner : {cursor.fetchone()[0]}"
         #)
         logger.info(
-            f"2. Number of datasets in {notsubclass} without fk_dataowner (tttt) : {tttt}"
+            f"Number of datasets in {notsubclass} without fk_dataowner (tttt) : {class_fk_dataowner_count}"
         )
 
         # if cursor.fetchone() is None:
-        if tttt == 0:
+        if class_fk_dataowner_count == 0:
             missing_fk_dataowner_count = missing_fk_dataowner_count
         else:
             #missing_fk_dataowner_count = missing_fk_dataowner_count + int(cursor.fetchone()[0])
-            missing_fk_dataowner_count = missing_fk_dataowner_count + tttt
+            missing_fk_dataowner_count = missing_fk_dataowner_count + class_fk_dataowner_count
 
         # add for testing 
         logger.info(
@@ -363,6 +383,7 @@ def check_fk_provider_null():
     cursor = connection.cursor()
 
     missing_fk_provider_count = 0
+    # add MANDATORY classes to be checked
     for notsubclass in [
         # VSA-KEK
         ("file"),
@@ -408,28 +429,21 @@ def check_fk_provider_null():
             f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE fk_provider is null;"
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
+        # add variable and store result of cursor.fetchone()[0] as the next call will give None value instead of count https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
+        class_fk_provider_count = int(cursor.fetchone()[0])
+        #logger.info(
+        #    f"Number of datasets in {notsubclass} without fk_provider : {cursor.fetchone()[0]}"
+        #)
         logger.info(
-            f"Number of datasets in {notsubclass} without fk_provider : {cursor.fetchone()[0]}"
+            f"Number of datasets in {notsubclass} without fk_dataowner (tttt) : {class_fk_provider_count}"
         )
 
-        # if no data in class cursor will be None
-        if cursor.fetchone() is None:
+        #if cursor.fetchone() is None:
+        if class_fk_provider_count == 0:
             missing_fk_provider_count = missing_fk_provider_count
-            # add for testing 
-            logger.info(
-                f"No data in class {notsubclass}"
-            )
-            #logger.info(
-            #    f"cursor.fetchone() is None : {int(cursor.fetchone()[0])}"
-            #)
         else:
-            if int(cursor.fetchone()[0]) == 0:
-                # missing_fk_provider_count = missing_fk_provider_count
-                logger.info(
-                    f"{(cursor.fetchone()[0])} missing fk_provider in class {notsubclass}"
-                )
-            else:
-                missing_fk_provider_count = missing_fk_provider_count + int(cursor.fetchone()[0])
+            # missing_fk_provider_count = missing_fk_provider_count
+            missing_fk_provider_count = missing_fk_provider_count + class_fk_provider_count
 
         # add for testing 
         logger.info(

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -456,10 +456,10 @@ def check_fk_provider_null():
 
 
 def get_wwtp_structure_ids():
-    # get list of id's of class wwtp_strucuture (ARABauwerk)
+    # get list of id's of class wwtp_structure (ARABauwerk)
 
-    logger.info("get list of id's of class wwtp_strucuture (ARABauwerk)...")
-    print("get list of id's of class wwtp_strucuture (ARABauwerk)...")
+    logger.info("get list of id's of class wwtp_structure (ARABauwerk)...")
+    print("get list of id's of class wwtp_structure (ARABauwerk)...")
 
     connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
     connection.set_session(autocommit=True)
@@ -467,7 +467,7 @@ def get_wwtp_structure_ids():
 
     wwtp_structure_ids = []
 
-    cursor.execute(f"select obj_id from qgep_od.wwtp_strucuture;")
+    cursor.execute(f"select obj_id from qgep_od.wwtp_structure;")
     # cursor.fetchall() - see https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
     wwtp_structure_count = int(cursor.fetchone()[0])
     if wwtp_structure_count == 0:

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -199,11 +199,16 @@ def check_fk_owner_null():
         else:
             missing_fk_owner_count = missing_fk_owner_count + int(cursor.fetchone()[0])
 
+        # add for testing 
+        logger.info(
+            f"missing_fk_owner_count : {missing_fk_owner_count}"
+        )
+
     if missing_fk_owner_count == 0:
         check_fk_owner_null = True
         logger.info("OK: all mandatory fk_owner set in qgep_od!")
     else:
-        missing_fk_owner_count = False
+        check_fk_owner_null = False
         logger.info(f"ERROR: Missing mandatory fk_owner in qgep_od: {missing_fk_owner_count}")
         print(f"ERROR: Missing mandatory fk_owner: {missing_fk_owner_count}")
 
@@ -237,12 +242,16 @@ def check_fk_operator_null():
             missing_fk_operator_count = missing_fk_operator_count
         else:
             missing_fk_operator_count = missing_fk_operator_count + int(cursor.fetchone()[0])
+        # add for testing 
+        logger.info(
+            f"missing_fk_operator_count : {missing_fk_operator_count}"
+        )
 
     if missing_fk_operator_count == 0:
         check_fk_operator_null = True
         logger.info("OK: all mandatory fk_operator set in qgep_od!")
     else:
-        missing_fk_operator_count = False
+        check_fk_operator_null = False
         logger.info(
             f"ERROR: Missing mandatory fk_operator in qgep_od: {missing_fk_operator_count}"
         )
@@ -307,20 +316,34 @@ def check_fk_dataowner_null():
             f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE fk_dataowner is null;"
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
+        
+        # hilfvariable
+        tttt = int(cursor.fetchone()[0])
+        
+        #logger.info(
+        #    f"Number of datasets in {notsubclass} without fk_dataowner : {cursor.fetchone()[0]}"
+        #)
         logger.info(
-            f"Number of datasets in {notsubclass} without fk_dataowner : {cursor.fetchone()[0]}"
+            f"2. Number of datasets in {notsubclass} without fk_dataowner (tttt) : {tttt}"
         )
 
-        if cursor.fetchone() is None:
+        # if cursor.fetchone() is None:
+        if tttt == 0:
             missing_fk_dataowner_count = missing_fk_dataowner_count
         else:
-            missing_fk_dataowner_count = missing_fk_dataowner_count + int(cursor.fetchone()[0])
+            #missing_fk_dataowner_count = missing_fk_dataowner_count + int(cursor.fetchone()[0])
+            missing_fk_dataowner_count = missing_fk_dataowner_count + tttt
+
+        # add for testing 
+        logger.info(
+            f"missing_fk_dataowner_count : {missing_fk_dataowner_count}"
+        )
 
     if missing_fk_dataowner_count == 0:
         check_fk_dataowner_null = True
         logger.info("OK: all mandatory fk_dataowner set in qgep_od!")
     else:
-        missing_fk_dataowner_count = False
+        check_fk_dataowner_null = False
         logger.info(
             f"ERROR: Missing mandatory fk_dataowner in qgep_od: {missing_fk_dataowner_count}"
         )
@@ -389,16 +412,35 @@ def check_fk_provider_null():
             f"Number of datasets in {notsubclass} without fk_provider : {cursor.fetchone()[0]}"
         )
 
+        # if no data in class cursor will be None
         if cursor.fetchone() is None:
             missing_fk_provider_count = missing_fk_provider_count
+            # add for testing 
+            logger.info(
+                f"No data in class {notsubclass}"
+            )
+            #logger.info(
+            #    f"cursor.fetchone() is None : {int(cursor.fetchone()[0])}"
+            #)
         else:
-            missing_fk_provider_count = missing_fk_provider_count + int(cursor.fetchone()[0])
+            if int(cursor.fetchone()[0]) == 0:
+                # missing_fk_provider_count = missing_fk_provider_count
+                logger.info(
+                    f"{(cursor.fetchone()[0])} missing fk_provider in class {notsubclass}"
+                )
+            else:
+                missing_fk_provider_count = missing_fk_provider_count + int(cursor.fetchone()[0])
+
+        # add for testing 
+        logger.info(
+            f"missing_fk_provider_count : {missing_fk_provider_count}"
+        )
 
     if missing_fk_provider_count == 0:
         check_fk_provider_null = True
         logger.info("OK: all mandatory fk_provider set in qgep_od!")
     else:
-        missing_fk_provider_count = False
+        check_fk_provider_null = False
         logger.info(
             f"ERROR: Missing mandatory fk_provider in qgep_od: {missing_fk_provider_count}"
         )

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -189,7 +189,7 @@ def check_fk_owner_null():
         ("wastewater_structure"),
     ]:
         cursor.execute(
-            f"SELECT COUNT(obj_id) FROM qgep_od.{missing_fk_owner_count} WHERE fk_owner is null;"
+            f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE fk_owner is null;"
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
         logger.info(
@@ -306,7 +306,7 @@ def check_fk_dataowner_null():
         ("zone"),
     ]:
         cursor.execute(
-            f"SELECT COUNT(obj_id) FROM qgep_od.{missing_fk_dataowner_count} WHERE fk_dataowner is null;"
+            f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE fk_dataowner is null;"
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
         logger.info(
@@ -384,7 +384,7 @@ def check_fk_provider_null():
         ("zone"),
     ]:
         cursor.execute(
-            f"SELECT COUNT(obj_id) FROM qgep_od.{missing_fk_provider_count} WHERE fk_provider is null;"
+            f"SELECT COUNT(obj_id) FROM qgep_od.{notsubclass} WHERE fk_provider is null;"
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
         logger.info(

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -212,7 +212,7 @@ def check_fk_owner_null():
     return check_fk_owner_null
 
 
-# Checking if MAMDATORY eigentuemerref not is Null
+# Checking if MAMDATORY betreiberref not is Null
 def check_fk_operator_null():
 
     logger.info("INTEGRITY CHECK missing MAMDATORY operator references fk_operator...")

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -467,10 +467,14 @@ def get_wwtp_structure_ids():
 
     wwtp_structure_ids = []
 
-    cursor.execute(f"select obj_id from qgep_od.wwtp_structure;")
+    # select all obj_id from wwtp_structure
+    cursor.execute(
+        f"SELECT obj_id FROM qgep_od.wwtp_structure;"
+    )
     # cursor.fetchall() - see https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
-    wwtp_structure_count = int(cursor.fetchone()[0])
-    if wwtp_structure_count == 0:
+    #wwtp_structure_count = int(cursor.fetchone()[0])
+    #if wwtp_structure_count == 0:
+    if cursor.fetchone() is None:
         wwtp_structure_ids = None
     else:
         records = cursor.fetchall()

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -436,7 +436,7 @@ def check_fk_provider_null():
         if class_fk_provider_count == 0:
             missing_fk_provider_count = missing_fk_provider_count
         else:
-            # missing_fk_provider_count = missing_fk_provider_count
+            # missing_fk_provider_count = missing_fk_provider_count + int(cursor.fetchone()[0])
             missing_fk_provider_count = missing_fk_provider_count + class_fk_provider_count
 
         # add for testing
@@ -453,6 +453,32 @@ def check_fk_provider_null():
         print(f"ERROR: Missing mandatory fk_provider: {missing_fk_provider_count}")
 
     return check_fk_provider_null
+
+def get_wwtp_structure_ids():
+# get list of id's of class wwtp_strucuture (ARABauwerk)
+
+    logger.info("get list of id's of class wwtp_strucuture (ARABauwerk)...")
+    print("get list of id's of class wwtp_strucuture (ARABauwerk)...")
+
+    connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
+    connection.set_session(autocommit=True)
+    cursor = connection.cursor()
+
+    wwtp_structure_ids = []
+
+    cursor.execute(
+        f"select obj_id from qgep_od.wwtp_strucuture;"
+    )
+    # cursor.fetchall() - see https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
+    wwtp_structure_count = int(cursor.fetchone()[0])
+    if wwtp_structure_count == 0:
+        wwtp_structure_ids = None
+    else:
+        records = cursor.fetchall()
+        for row in records:
+            wwtp_structure_ids = wwtp_structure_ids + row[0] + ','
+
+    return wwtp_structure_ids
 
 
 def create_ili_schema(schema, model, log_path, recreate_schema=False):

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -323,7 +323,80 @@ def check_fk_dataowner_null():
 
     return check_fk_dataowner_null
 
+# Checking if MAMDATORY datenlieferantref not is Null
+def check_fk_provider_null():
 
+    logger.info("INTEGRITY CHECK missing provider references fk_provider...")
+    print("INTEGRITY CHECK missing provider references fk_provider...")
+
+    connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
+    connection.set_session(autocommit=True)
+    cursor = connection.cursor()
+
+    missing_fk_provider_count = 0
+    for notsubclass in [
+        # VSA-KEK
+        ("file"),
+        ("data_media"),
+        ("maintenance_event"),
+        # SIA405 Abwasser
+        ("organisation"),
+        ("wastewater_structure"),
+        ("wastewater_networkelement"),
+        ("structure_part"),
+        ("reach_point"),
+        ("pipe_profile"),
+        # VSA-DSS
+        ("catchment_area"),
+        ("connection_object"),
+        ("control_center"),
+        ("hazard_source"),
+        ("hydr_geometry"),
+        ("hydraulic_char_data"),
+        ("measurement_result"),
+        ("measurement_series"),
+        ("measuring_device"),
+        ("measuring_point"),
+        ("mechanical_pretreatment"),
+        ("overflow"),
+        ("overflow_char"),
+        ("retention_body"),
+        ("river_bank"),
+        ("river_bed"),
+        ("sector_water_body"),
+        ("substance"),
+        ("surface_runoff_parameters"),
+        ("surface_water_bodies"),
+        ("throttle_shut_off_unit"),
+        ("waste_water_treatment"),
+        ("water_catchment"),
+        ("water_control_structure"),
+        ("water_course_segment"),
+        ("wwtp_energy_use"),
+        ("zone"),
+    ]:
+        cursor.execute(
+            f"SELECT COUNT(obj_id) FROM qgep_od.{missing_fk_provider_count} WHERE fk_provider is null;"
+        )
+        # use cursor.fetchone()[0] instead of cursor.rowcount
+        logger.info(
+            f"Number of datasets in {notsubclass} without fk_provider : {cursor.fetchone()[0]}"
+        )
+
+        if cursor.fetchone() is None:
+            missing_fk_provider_count = missing_fk_provider_count
+        else:
+            missing_fk_provider_count = missing_fk_provider_count + int(cursor.fetchone()[0])
+
+    if missing_fk_provider_count == 0:
+        check_fk_provider_null = True
+        logger.info("OK: all mandatory fk_provider set in qgep_od!")
+    else:
+        missing_fk_provider_count = False
+        logger.info(f"ERROR: Missing mandatory fk_provider in qgep_od: {missing_fk_provider_count}")
+        print(f"ERROR: Missing mandatory fk_provider: {missing_fk_provider_count}")
+
+    return check_fk_provider_null
 
 def create_ili_schema(schema, model, log_path, recreate_schema=False):
     logger.info("CONNECTING TO DATABASE...")

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -471,10 +471,10 @@ def skip_wwtp_structure_ids():
     cursor.execute(
         f"SELECT * FROM qgep_od.wastewater_structure WHERE obj_id NOT IN (SELECT obj_id FROM qgep_od.wwtp_structure);"
     )
-    #remove - only for testing
-    #cursor.execute(
+    # remove - only for testing
+    # cursor.execute(
     #   f"SELECT * FROM qgep_od.organisation WHERE obj_id NOT IN (SELECT obj_id FROM qgep_od.private);"
-    #)
+    # )
 
     # cursor.fetchall() - see https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
     # wwtp_structure_count = int(cursor.fetchone()[0])
@@ -488,8 +488,8 @@ def skip_wwtp_structure_ids():
             # https://www.pythontutorial.net/python-string-methods/python-string-concatenation/
             # not_wwtp_structure_ids = not_wwtp_structure_ids + str(row[0]) + ","
             strrow = str(row[0])
-            #not_wwtp_structure_ids = ','.join([not_wwtp_structure_ids, strrow])
-            #not_wwtp_structure_ids = not_wwtp_structure_ids + row[0]
+            # not_wwtp_structure_ids = ','.join([not_wwtp_structure_ids, strrow])
+            # not_wwtp_structure_ids = not_wwtp_structure_ids + row[0]
             not_wwtp_structure_ids.append(strrow)
             logger.info(f" building up '{not_wwtp_structure_ids}' ...")
 

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -172,6 +172,43 @@ def check_identifier_null():
 
     return identifier_null_check
 
+# Checking if MAMDATORY eigentuemerref not is Null
+def check_fk_owner_null():
+
+    logger.info("INTEGRITY CHECK missing owner references fk_owner...")
+    print("INTEGRITY CHECK missing owner references fk_owner...")
+
+    connection = psycopg2.connect(get_pgconf_as_psycopg2_dsn())
+    connection.set_session(autocommit=True)
+    cursor = connection.cursor()
+
+    missing_fk_owner_count = 0
+    for notsubclass in [
+        # SIA405 Abwasser
+        ("wastewater_structure"),
+    ]:
+        cursor.execute(
+            f"SELECT COUNT(obj_id) FROM qgep_od.{missing_fk_owner_count} WHERE fk_owner is null;"
+        )
+        # use cursor.fetchone()[0] instead of cursor.rowcount
+        logger.info(
+            f"Number of datasets in {notsubclass} without fk_owner : {cursor.fetchone()[0]}"
+        )
+
+        if cursor.fetchone() is None:
+            missing_fk_owner_count = missing_fk_owner_count
+        else:
+            missing_fk_owner_count = missing_fk_owner_count + int(cursor.fetchone()[0])
+
+    if missing_fk_owner_count == 0:
+        check_fk_owner_null = True
+        logger.info("OK: all mandatory fk_owner set in qgep_od!")
+    else:
+        missing_fk_owner_count = False
+        logger.info(f"ERROR: Missing mandatory fk_owner in qgep_od: {missing_fk_owner_count}")
+        print(f"ERROR: Missing mandatory fk_owner: {missing_fk_owner_count}")
+
+    return check_fk_owner_null
 
 def create_ili_schema(schema, model, log_path, recreate_schema=False):
     logger.info("CONNECTING TO DATABASE...")

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -157,7 +157,7 @@ def check_identifier_null():
         # add variable and store result of cursor.fetchone()[0] as the next call will give None value instead of count https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
         class_identifier_count = int(cursor.fetchone()[0])
         logger.info(
-            f"Number of datasets in {notsubclass} without fk_dataowner (tttt) : {class_identifier_count}"
+            f"Number of datasets in class '{notsubclass}' without identifier : {class_identifier_count}"
         )
 
         # if cursor.fetchone() is None:
@@ -170,7 +170,7 @@ def check_identifier_null():
             )
 
         # add for testing
-        logger.info(f"missing_fk_dataowner_count : {missing_identifier_count}")
+        logger.info(f"missing_identifier_count : {missing_identifier_count}")
 
     if missing_identifier_count == 0:
         identifier_null_check = True
@@ -204,10 +204,10 @@ def check_fk_owner_null():
         # add variable and store result of cursor.fetchone()[0] as the next call will give None value instead of count https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
         class_fk_owner_count = int(cursor.fetchone()[0])
         # logger.info(
-        #    f"Number of datasets in {notsubclass} without fk_owner : {cursor.fetchone()[0]}"
+        #    f"Number of datasets in class '{notsubclass}' without fk_owner : {cursor.fetchone()[0]}"
         # )
         logger.info(
-            f"Number of datasets in {notsubclass} without fk_owner (tttt) : {class_fk_owner_count}"
+            f"Number of datasets in class '{notsubclass}' without fk_owner : {class_fk_owner_count}"
         )
 
         # if cursor.fetchone() is None:
@@ -253,7 +253,7 @@ def check_fk_operator_null():
         )
         # use cursor.fetchone()[0] instead of cursor.rowcount
         logger.info(
-            f"Number of datasets in {notsubclass} without fk_operator : {cursor.fetchone()[0]}"
+            f"Number of datasets in class '{notsubclass}' without fk_operator : {cursor.fetchone()[0]}"
         )
 
         if cursor.fetchone() is None:
@@ -337,10 +337,10 @@ def check_fk_dataowner_null():
         class_fk_dataowner_count = int(cursor.fetchone()[0])
 
         # logger.info(
-        #    f"Number of datasets in {notsubclass} without fk_dataowner : {cursor.fetchone()[0]}"
+        #    f"Number of datasets in class '{notsubclass}' without fk_dataowner : {cursor.fetchone()[0]}"
         # )
         logger.info(
-            f"Number of datasets in {notsubclass} without fk_dataowner (tttt) : {class_fk_dataowner_count}"
+            f"Number of datasets in class '{notsubclass}' without fk_dataowner : {class_fk_dataowner_count}"
         )
 
         # if cursor.fetchone() is None:
@@ -426,10 +426,10 @@ def check_fk_provider_null():
         # add variable and store result of cursor.fetchone()[0] as the next call will give None value instead of count https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
         class_fk_provider_count = int(cursor.fetchone()[0])
         # logger.info(
-        #    f"Number of datasets in {notsubclass} without fk_provider : {cursor.fetchone()[0]}"
+        #    f"Number of datasets in class '{notsubclass}' without fk_provider : {cursor.fetchone()[0]}"
         # )
         logger.info(
-            f"Number of datasets in {notsubclass} without fk_dataowner (tttt) : {class_fk_provider_count}"
+            f"Number of datasets in class '{notsubclass}' without fk_dataowner : {class_fk_provider_count}"
         )
 
         # if cursor.fetchone() is None:

--- a/qgepqwat2ili/utils/ili2db.py
+++ b/qgepqwat2ili/utils/ili2db.py
@@ -455,8 +455,8 @@ def check_fk_provider_null():
     return check_fk_provider_null
 
 
-def get_wwtp_structure_ids():
-    # get list of id's of class wwtp_structure (ARABauwerk)
+def skip_wwtp_structure_ids():
+    # get list of id's of class wastewater_structure without wwtp_structure (ARABauwerk)
 
     logger.info("get list of id's of class wwtp_structure (ARABauwerk)...")
     print("get list of id's of class wwtp_structure (ARABauwerk)...")
@@ -465,23 +465,35 @@ def get_wwtp_structure_ids():
     connection.set_session(autocommit=True)
     cursor = connection.cursor()
 
-    wwtp_structure_ids = []
+    not_wwtp_structure_ids = []
 
-    # select all obj_id from wwtp_structure
+    # select all obj_id from wastewater_structure that are not in wwtp_structure
     cursor.execute(
-        f"SELECT obj_id FROM qgep_od.wwtp_structure;"
+        f"SELECT * FROM qgep_od.wastewater_structure WHERE obj_id NOT IN (SELECT obj_id FROM qgep_od.wwtp_structure);"
     )
+    #remove - only for testing
+    #cursor.execute(
+    #   f"SELECT * FROM qgep_od.organisation WHERE obj_id NOT IN (SELECT obj_id FROM qgep_od.private);"
+    #)
+    
     # cursor.fetchall() - see https://pynative.com/python-cursor-fetchall-fetchmany-fetchone-to-read-rows-from-table/
     #wwtp_structure_count = int(cursor.fetchone()[0])
     #if wwtp_structure_count == 0:
     if cursor.fetchone() is None:
-        wwtp_structure_ids = None
+        not_wwtp_structure_ids = None
     else:
         records = cursor.fetchall()
         for row in records:
-            wwtp_structure_ids = wwtp_structure_ids + row[0] + ","
+            logger.info(f" row[0] = {row[0]}")
+            # https://www.pythontutorial.net/python-string-methods/python-string-concatenation/
+            # not_wwtp_structure_ids = not_wwtp_structure_ids + str(row[0]) + ","
+            strrow = str(row[0])
+            #not_wwtp_structure_ids = ','.join([not_wwtp_structure_ids, strrow])
+            #not_wwtp_structure_ids = not_wwtp_structure_ids + row[0]
+            not_wwtp_structure_ids.append(strrow)
+            logger.info(f" building up '{not_wwtp_structure_ids}' ...")
 
-    return wwtp_structure_ids
+    return not_wwtp_structure_ids
 
 
 def create_ili_schema(schema, model, log_path, recreate_schema=False):


### PR DESCRIPTION
Adds additional checks for references

- [x] fk_owner (only the ones that are MANDATORY)
- [x] fk_operator (only the ones that are MANDATORY)
- [x] fk_dataowner (all, as preparation for beeing MANDATORY in VSA-DSS / SIA405 Abwasser 2020.xx)
- [x] fk_provider (all, as preparation for beeing MANDATORY in VSA-DSS / SIA405 Abwasser 2020.xx)

Export will not be cancelled if fk_dataowner and fk_provider are missing, as we will get errors anyway (updated 4.10.2024)
