### PR TITLE
Explicitly setup DB for test case f

### DIFF
--- a/qgepqwat2ili/tests/test_qgep.py
+++ b/qgepqwat2ili/tests/test_qgep.py
@@ -219,6 +219,9 @@ class TestQGEPUseCases(unittest.TestCase):
         # F. export a selection
         """
 
+        # Prepare db
+        main(["setupdb", "full"])
+
         path = os.path.join(tempfile.mkdtemp(), "export_VSA_KEK_2019_LV95.xtf")
         selection = [
             # reach_id


### PR DESCRIPTION
To avoid using the wrong data when test order changes